### PR TITLE
feat: daily notes support postfix

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1209,7 +1209,7 @@ export default class VCWPlugin extends Plugin {
     
       formattedDailyData = {} as any;
       for (let i = 0; i < 15; i++) {
-        if (fname === l1results.days[i].datetime) {
+        if (fname.startsWith(l1results.days[i].datetime)) {
           // Get data from existing future dates
           formattedDailyData = Object.values(l1formattedresults)[i+3];
           break;
@@ -1218,7 +1218,7 @@ export default class VCWPlugin extends Plugin {
       if (Object.keys(formattedDailyData).length == 0) {
         // Get data by past date
         for (let i = 1; i < 15; i++) {
-          if (fname === window.moment().subtract(i, "days").format("YYYY-MM-DD")) {
+          if (fname.startsWith(window.moment().subtract(i, "days").format("YYYY-MM-DD"))) {
 
             // • Get weather for daily notes • 
             const getResults = new UpdateWeather();


### PR DESCRIPTION
# Add Support for Daily Notes Filename Postfix

## Changes
- Modified Daily Notes template macros to support filename postfixes
- Previously only supported exact `YYYY-MM-DD` format, now supports any filename that starts with `YYYY-MM-DD`

## Technical Details
- Updated date comparison logic in `src/main.ts`:
  - Changed from exact match (`===`) to `startsWith()` to check if filename begins with the date
  - Applied the same logic for both future and past dates

## Usage Examples
The following filename formats are now supported:
- `2024-03-20.md`
- `2024-03-20-Wednesday.md`
- `2024-03-20-daily.md`
- `2024-03-20-notes.md`

## Related Documentation
- [Daily Notes Template Macros Documentation](https://github.com/willasm/vc-weather?tab=readme-ov-file#daily-notes-template-macros)